### PR TITLE
Switch to using `wimsplit` in place of `wimlib-imagex split`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ hdiutil attach ~/Downloads/Win10_VERSION_LANG_ARCH.iso -mountpoint /Volumes/WINI
 rsync -v -r -I --no-links --no-perms --no-owner --no-group --exclude sources/install.wim /Volumes/WINISO/ /Volumes/WININST/
 
 # Split-copy install.wim
-wimlib-imagex split /Volumes/WINISO/sources/install.wim /Volumes/WININST/sources/install.swm 1024
+wimsplit /Volumes/WINISO/sources/install.wim /Volumes/WININST/sources/install.swm 1024
 
 # Ensure all data is written and detach all devices
 sync


### PR DESCRIPTION
`wimlib-imagex split` works perfectly fine but these are equivalent commands and `wimsplit` is a little more intuitively named.

```
NAME
       wimsplit - Split a WIM archive into multiple parts

SYNOPSIS
       wimsplit WIMFILE SPLIT_WIM_PART_1 PART_SIZE [OPTION...]

DESCRIPTION
       wimsplit,  or  equivalently  wimlib-imagex  split,  splits  WIMFILE into parts with size at most PART_SIZE mebibytes (power-of-2
       megabytes), with the first part having the name SPLIT_WIM_PART_1 and the other parts having  names  numbered  in  order  of  the
       parts.
```

As an aside, I spent 3 hours trying to get a Windows FAT32 boot USB created on a mac and yours was the only process that worked.  Thanks!